### PR TITLE
Added tests for mixed case attributes in aggregates

### DIFF
--- a/interfaces/queryable/modifiers/average.modifier.test.js
+++ b/interfaces/queryable/modifiers/average.modifier.test.js
@@ -20,6 +20,7 @@ describe('Queryable Interface', function() {
           first_name: 'average_user' + i,
           type: 'average test',
           age: i,
+          ageInYears: i,
           percent: i/2
         });
       }
@@ -38,6 +39,14 @@ describe('Queryable Interface', function() {
       Queryable.User.find({ where:{type: 'average test'}, average: ['age'] }, function(err, averages) {
         assert(!err,err);
         assert.strictEqual(averages[0].age, 4.5, 'expected averages[0].age to === 4.5, instead averages ==='+require('util').inspect(averages, false, null));
+        done();
+      });
+    });
+
+    it('should average by key and only return that key with the average value - mixed case attribute', function(done) {
+      Queryable.User.find({ where:{type: 'average test'}, average: ['ageInYears'] }, function(err, averages) {
+        assert(!err,err);
+        assert.strictEqual(averages[0].ageInYears, 4.5, 'expected averages[0].ageInYears to === 4.5, instead averages ==='+require('util').inspect(averages, false, null));
         done();
       });
     });

--- a/interfaces/queryable/modifiers/max.modifier.test.js
+++ b/interfaces/queryable/modifiers/max.modifier.test.js
@@ -20,6 +20,7 @@ describe('Queryable Interface', function() {
           first_name: 'max_user' + i,
           type: 'max test',
           age: i + 9001,
+          ageInYears: i + 9001,
           percent: i/2 + 9001
         });
       }
@@ -38,6 +39,14 @@ describe('Queryable Interface', function() {
       Queryable.User.find({where:{type: 'max test'}, max: ['age'] }, function(err, summed) {
         assert(!err);
         assert.strictEqual(summed[0].age, 9010);
+        done();
+      });
+    });
+
+    it('should get the maximum of the key - mixed case attribute', function(done) {
+      Queryable.User.find({where:{type: 'max test'}, max: ['ageInYears'] }, function(err, summed) {
+        assert(!err);
+        assert.strictEqual(summed[0].ageInYears, 9010);
         done();
       });
     });

--- a/interfaces/queryable/modifiers/min.modifier.test.js
+++ b/interfaces/queryable/modifiers/min.modifier.test.js
@@ -20,6 +20,7 @@ describe('Queryable Interface', function() {
           first_name: 'min_user' + i,
           type: 'min test',
           age: -i,
+          ageInYears: -i,
           percent: -i/2
         });
       }
@@ -38,6 +39,14 @@ describe('Queryable Interface', function() {
       Queryable.User.find({ where:{type: 'min test'}, min: ['age'] }, function(err, summed) {
         assert(!err);
         assert.strictEqual(summed[0].age, -9);
+        done();
+      });
+    });
+
+    it('should get the minimum of the key - mixed case attribute', function(done) {
+      Queryable.User.find({ where:{type: 'min test'}, min: ['ageInYears'] }, function(err, summed) {
+        assert(!err);
+        assert.strictEqual(summed[0].ageInYears, -9);
         done();
       });
     });

--- a/interfaces/queryable/modifiers/sum.modifier.test.js
+++ b/interfaces/queryable/modifiers/sum.modifier.test.js
@@ -20,6 +20,7 @@ describe('Queryable Interface', function() {
           first_name: 'sum_user' + i,
           type: 'sum test',
           age: i,
+          ageInYears: i,
           percent: i/2
         });
       }
@@ -38,6 +39,14 @@ describe('Queryable Interface', function() {
       Queryable.User.find({ where:{type: 'sum test'}, sum: ['age'] }, function(err, summed) {
         assert(!err);
         assert.strictEqual(summed[0].age, 45);
+        done();
+      });
+    });
+
+    it('should sum by key and only return that key with the sum value - mixed case attribute', function(done) {
+      Queryable.User.find({ where:{type: 'sum test'}, sum: ['ageInYears'] }, function(err, summed) {
+        assert(!err);
+        assert.strictEqual(summed[0].ageInYears, 45);
         done();
       });
     });

--- a/interfaces/queryable/support/fixtures/crud.fixture.js
+++ b/interfaces/queryable/support/fixtures/crud.fixture.js
@@ -22,6 +22,7 @@ module.exports = Waterline.Collection.extend({
       type: 'string'
     },
     age: 'integer', // integer field that's not auto-incrementable
+    ageInYears: 'integer', // mixed case attribute
     dob: 'date',
     status: {
       type: 'boolean',


### PR DESCRIPTION
This PR provides failing tests cases for https://github.com/waterlinejs/postgresql-adapter/issues/3. Assuming https://github.com/waterlinejs/waterline-sequel/pull/1 is accepted and the postgresql-adapter dependency is updated to the latest waterline-sequel than these tests will pass.
